### PR TITLE
updated the identifier for basket items from 'id' to '_id' because Sa…

### DIFF
--- a/client/screens/CartScreen.js
+++ b/client/screens/CartScreen.js
@@ -19,10 +19,10 @@ export default function BasketScreen() {
     const deliveryFee = 2;
     useMemo(() => {
         const gItems = basketItems.reduce((group, item)=>{
-            if(group[item.id]){
-              group[item.id].push(item);
+            if(group[item._id]){
+              group[item._id].push(item);
             }else{
-              group[item.id] = [item];
+              group[item._id] = [item];
             }
             return group;
           },{})


### PR DESCRIPTION
I updated the identifier for basket items from 'id' to '_id' because Sanity stores the identifier as '_id' instead of 'id' in the cart screen. 